### PR TITLE
Fix SwiftUI build errors in AI coach and journal

### DIFF
--- a/Dopamine Detox/ViewModels/JournalViewModel.swift
+++ b/Dopamine Detox/ViewModels/JournalViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 @MainActor
 final class JournalViewModel: ObservableObject {

--- a/Dopamine Detox/Views/AICoachView.swift
+++ b/Dopamine Detox/Views/AICoachView.swift
@@ -78,7 +78,7 @@ struct AICoachView: View {
         HStack {
             if message.sender == .coach {
                 Image(systemName: "sparkles")
-                    .foregroundStyle(.accent)
+                    .foregroundStyle(Color.accentColor)
             } else {
                 Spacer(minLength: 32)
             }


### PR DESCRIPTION
## Summary
- replace the invalid ShapeStyle.accent usage with Color.accentColor in the AI coach view
- add the missing Combine import required for @Published properties in the journal view model

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24d10dd88832b86efc4083844e2f2