### PR TITLE
Integrate RevenueCat paywall after free detox session

### DIFF
--- a/Dopamine Detox.xcodeproj/project.pbxproj
+++ b/Dopamine Detox.xcodeproj/project.pbxproj
@@ -4,7 +4,12 @@
 	classes = {
 	};
 	objectVersion = 77;
-	objects = {
+        objects = {
+
+/* Begin PBXBuildFile section */
+                B6F1AA1C2FB23FBC00D12345 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = B6F1AA222FB23FBC00D12345 /* RevenueCat */; };
+                B6F1AA1D2FB23FBC00D12345 /* RevenueCatUI in Frameworks */ = {isa = PBXBuildFile; productRef = B6F1AA232FB23FBC00D12345 /* RevenueCatUI */; };
+/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		5AE3D9092E9261D900907AC9 /* PBXContainerItemProxy */ = {
@@ -61,13 +66,15 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5AE3D8F42E9261D700907AC9 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                5AE3D8F42E9261D700907AC9 /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                B6F1AA1C2FB23FBC00D12345 /* RevenueCat in Frameworks */,
+                                B6F1AA1D2FB23FBC00D12345 /* RevenueCatUI in Frameworks */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		5AE3D9052E9261D900907AC9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -124,8 +131,10 @@
 				5AE3D8F92E9261D700907AC9 /* Dopamine Detox */,
 			);
 			name = "Dopamine Detox";
-			packageProductDependencies = (
-			);
+                        packageProductDependencies = (
+                                B6F1AA222FB23FBC00D12345 /* RevenueCat */,
+                                B6F1AA232FB23FBC00D12345 /* RevenueCatUI */,
+                        );
 			productName = "Dopamine Detox";
 			productReference = 5AE3D8F72E9261D700907AC9 /* Dopamine Detox.app */;
 			productType = "com.apple.product-type.application";
@@ -210,14 +219,17 @@
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 5AE3D8F82E9261D700907AC9 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				5AE3D8F62E9261D700907AC9 /* Dopamine Detox */,
-				5AE3D9072E9261D900907AC9 /* Dopamine DetoxTests */,
-				5AE3D9112E9261D900907AC9 /* Dopamine DetoxUITests */,
-			);
-		};
+                        projectDirPath = "";
+                        projectRoot = "";
+                        targets = (
+                                5AE3D8F62E9261D700907AC9 /* Dopamine Detox */,
+                                5AE3D9072E9261D900907AC9 /* Dopamine DetoxTests */,
+                                5AE3D9112E9261D900907AC9 /* Dopamine DetoxUITests */,
+                        );
+                        packageReferences = (
+                                B6F1AA242FB23FBC00D12345 /* XCRemoteSwiftPackageReference "purchases-ios" */,
+                        );
+                };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -280,6 +292,17 @@
 			targetProxy = 5AE3D9132E9261D900907AC9 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+                B6F1AA242FB23FBC00D12345 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
+                        isa = XCRemoteSwiftPackageReference;
+                        repositoryURL = "https://github.com/RevenueCat/purchases-ios";
+                        requirement = {
+                                kind = upToNextMajorVersion;
+                                minimumVersion = 4.38.0;
+                        };
+                };
+/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCBuildConfiguration section */
 		5AE3D91C2E9261D900907AC9 /* Debug */ = {
@@ -595,8 +618,21 @@
 				XROS_DEPLOYMENT_TARGET = 26.0;
 			};
 			name = Release;
-		};
+                };
 /* End XCBuildConfiguration section */
+
+/* Begin XCSwiftPackageProductDependency section */
+                B6F1AA222FB23FBC00D12345 /* RevenueCat */ = {
+                        isa = XCSwiftPackageProductDependency;
+                        package = B6F1AA242FB23FBC00D12345 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+                        productName = RevenueCat;
+                };
+                B6F1AA232FB23FBC00D12345 /* RevenueCatUI */ = {
+                        isa = XCSwiftPackageProductDependency;
+                        package = B6F1AA242FB23FBC00D12345 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+                        productName = RevenueCatUI;
+                };
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCConfigurationList section */
 		5AE3D8F22E9261D700907AC9 /* Build configuration list for PBXProject "Dopamine Detox" */ = {

--- a/Dopamine Detox/Dopamine_DetoxApp.swift
+++ b/Dopamine Detox/Dopamine_DetoxApp.swift
@@ -1,8 +1,13 @@
+import RevenueCat
 import SwiftUI
 
 @main
 struct Dopamine_DetoxApp: App {
     @StateObject private var appState = AppState()
+
+    init() {
+        Purchases.configure(withAPIKey: "appl_uhABinYKmAgGdqElwYoFRqkBTon")
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/Dopamine Detox/Models/AppState.swift
+++ b/Dopamine Detox/Models/AppState.swift
@@ -9,6 +9,7 @@ final class AppState: ObservableObject {
     @Published var totalFocusMinutes: Int
     @Published var activeSession: DetoxSession?
     @Published var pastSessions: [DetoxSession]
+    @Published var completedSessionCount: Int
     @Published var journalEntries: [JournalEntry]
     @Published var achievements: [Achievement]
 
@@ -17,6 +18,7 @@ final class AppState: ObservableObject {
         case onboardingCompleted
         case streak
         case totalFocusMinutes
+        case completedSessions
     }
 
     init(userDefaults: UserDefaults = .standard) {
@@ -32,6 +34,7 @@ final class AppState: ObservableObject {
         totalFocusMinutes = storedMinutes
         activeSession = nil
         pastSessions = []
+        completedSessionCount = defaults.object(forKey: StorageKeys.completedSessions.rawValue) as? Int ?? 0
         journalEntries = JournalEntry.sampleData
         achievements = Achievement.defaults()
     }
@@ -58,8 +61,10 @@ final class AppState: ObservableObject {
         } else {
             streak += 1
             totalFocusMinutes += Int(session.duration.rawValue / 60)
+            completedSessionCount += 1
             userDefaults.set(streak, forKey: StorageKeys.streak.rawValue)
             userDefaults.set(totalFocusMinutes, forKey: StorageKeys.totalFocusMinutes.rawValue)
+            userDefaults.set(completedSessionCount, forKey: StorageKeys.completedSessions.rawValue)
         }
 
         updateAchievements()

--- a/Dopamine Detox/ViewModels/DetoxTimerViewModel.swift
+++ b/Dopamine Detox/ViewModels/DetoxTimerViewModel.swift
@@ -1,5 +1,6 @@
-import Foundation
 import Combine
+import Foundation
+import RevenueCat
 
 @MainActor
 final class DetoxTimerViewModel: ObservableObject {
@@ -47,6 +48,24 @@ final class DetoxTimerViewModel: ObservableObject {
         isRunning = true
         showCelebration = false
         startTimer()
+    }
+
+    func requiresPaywallBeforeStartingSession() async -> (requiresPaywall: Bool, errorMessage: String?) {
+        let completedSessions = appState.completedSessionCount
+        guard completedSessions >= 1 else {
+            return (false, nil)
+        }
+
+        do {
+            let customerInfo = try await Purchases.shared.customerInfo()
+            let hasActiveEntitlement = customerInfo.entitlements.active.isEmpty == false
+            return (!hasActiveEntitlement, nil)
+        } catch {
+            return (
+                true,
+                "No pudimos verificar tu suscripción en este momento. Revisa tu conexión e inténtalo de nuevo."
+            )
+        }
     }
 
     func cancelSession() {


### PR DESCRIPTION
## Summary
- configure RevenueCat with the provided API key during app launch
- track completed detox sessions and gate new sessions behind a paywall after the free run
- show the native RevenueCat paywall and surface user feedback when subscription status cannot be verified

## Testing
- not run (iOS tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e26d69a254832b92f01e3ab8e22bb6