### PR TITLE
Add Focus Filter automation to detox sessions

### DIFF
--- a/Dopamine Detox/Services/FocusAutomationManager.swift
+++ b/Dopamine Detox/Services/FocusAutomationManager.swift
@@ -1,0 +1,189 @@
+import Foundation
+import os.log
+import UIKit
+#if canImport(FocusConfiguration)
+import FocusConfiguration
+#endif
+#if canImport(FocusConfigurationUI)
+import FocusConfigurationUI
+#endif
+
+@MainActor
+final class FocusAutomationManager: ObservableObject {
+    static let shared = FocusAutomationManager()
+
+    enum Status: Equatable {
+        case unsupported
+        case needsAuthorization
+        case denied
+        case needsConfiguration
+        case ready(name: String)
+    }
+
+    @Published private(set) var status: Status = .unsupported
+    @Published private(set) var isActivatingFocus = false
+    @Published private(set) var isDeactivatingFocus = false
+
+    private let logger = Logger(subsystem: "com.dopamine.detox", category: "FocusAutomation")
+    private let userDefaults: UserDefaults
+    private let identifierKey = "focusAutomation.selectedConfigurationIdentifier"
+    private let nameKey = "focusAutomation.selectedConfigurationName"
+
+    private init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        refreshStatus()
+    }
+
+    func refreshStatus() {
+#if canImport(FocusConfiguration)
+        guard #available(iOS 17, *) else {
+            status = .unsupported
+            return
+        }
+
+        switch FocusConfigurationManager.shared.authorizationStatus {
+        case .notDetermined:
+            status = .needsAuthorization
+        case .restricted, .denied:
+            status = .denied
+        case .authorized:
+            if storedConfigurationIdentifier != nil, let name = storedConfigurationName {
+                status = .ready(name: name)
+            } else {
+                status = .needsConfiguration
+            }
+        @unknown default:
+            status = .unsupported
+        }
+#else
+        status = .unsupported
+#endif
+    }
+
+    func requestAuthorizationIfNeeded() async {
+#if canImport(FocusConfiguration)
+        guard #available(iOS 17, *), status == .needsAuthorization else { return }
+
+        do {
+            try await FocusConfigurationManager.shared.requestAuthorization()
+        } catch {
+            logger.error("Focus authorization request failed: \(error.localizedDescription, privacy: .public)")
+        }
+
+        refreshStatus()
+#endif
+    }
+
+    func presentConfigurationPicker(from scene: UIWindowScene?) async {
+#if canImport(FocusConfigurationUI) && canImport(FocusConfiguration)
+        guard #available(iOS 17, *), status != .unsupported else { return }
+        guard let scene else {
+            logger.error("Missing UIWindowScene when presenting FocusConfigurationPicker")
+            return
+        }
+
+        do {
+            let picker = FocusConfigurationPicker(configurationKinds: [.filter])
+            let result = try await picker.present(from: scene)
+
+            switch result {
+            case .selection(let configuration):
+                storedConfigurationIdentifier = configuration.identifier
+                storedConfigurationName = configuration.localizedName
+                logger.info("Stored focus configuration \(configuration.localizedName, privacy: .public)")
+            case .none:
+                break
+            @unknown default:
+                break
+            }
+        } catch {
+            logger.error("Failed to present FocusConfigurationPicker: \(error.localizedDescription, privacy: .public)")
+        }
+
+        refreshStatus()
+#else
+        openSettings()
+#endif
+    }
+
+    func beginDetoxSession() {
+#if canImport(FocusConfiguration)
+        guard #available(iOS 17, *), case .ready = status else { return }
+        guard let identifier = storedConfigurationIdentifier else { return }
+
+        Task {
+            await activateFocusConfiguration(with: identifier)
+        }
+#endif
+    }
+
+    func endDetoxSession() {
+#if canImport(FocusConfiguration)
+        guard #available(iOS 17, *), let identifier = storedConfigurationIdentifier else { return }
+
+        Task {
+            await deactivateFocusConfiguration(with: identifier)
+        }
+#endif
+    }
+
+    func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+
+    private var storedConfigurationIdentifier: UUID? {
+        get {
+            guard let value = userDefaults.string(forKey: identifierKey) else { return nil }
+            return UUID(uuidString: value)
+        }
+        set {
+            if let newValue {
+                userDefaults.set(newValue.uuidString, forKey: identifierKey)
+            } else {
+                userDefaults.removeObject(forKey: identifierKey)
+            }
+        }
+    }
+
+    private var storedConfigurationName: String? {
+        get { userDefaults.string(forKey: nameKey) }
+        set {
+            if let newValue {
+                userDefaults.set(newValue, forKey: nameKey)
+            } else {
+                userDefaults.removeObject(forKey: nameKey)
+            }
+        }
+    }
+
+#if canImport(FocusConfiguration)
+    @available(iOS 17, *)
+    private func activateFocusConfiguration(with identifier: UUID) async {
+        guard !isActivatingFocus else { return }
+        isActivatingFocus = true
+        defer { isActivatingFocus = false }
+
+        do {
+            try await FocusConfigurationManager.shared.activateFocusConfiguration(withIdentifier: identifier)
+            logger.info("Activated focus configuration during detox session")
+        } catch {
+            logger.error("Failed to activate focus configuration: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    @available(iOS 17, *)
+    private func deactivateFocusConfiguration(with identifier: UUID) async {
+        guard !isDeactivatingFocus else { return }
+        isDeactivatingFocus = true
+        defer { isDeactivatingFocus = false }
+
+        do {
+            try await FocusConfigurationManager.shared.deactivateFocusConfiguration(withIdentifier: identifier)
+            logger.info("Deactivated focus configuration after detox session")
+        } catch {
+            logger.error("Failed to deactivate focus configuration: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+#endif
+}

--- a/Dopamine Detox/ViewModels/DetoxTimerViewModel.swift
+++ b/Dopamine Detox/ViewModels/DetoxTimerViewModel.swift
@@ -11,9 +11,11 @@ final class DetoxTimerViewModel: ObservableObject {
 
     private var timer: AnyCancellable?
     private unowned let appState: AppState
+    private let focusAutomationManager: FocusAutomationManager
 
-    init(appState: AppState) {
+    init(appState: AppState, focusAutomationManager: FocusAutomationManager = .shared) {
         self.appState = appState
+        self.focusAutomationManager = focusAutomationManager
         if let active = appState.activeSession {
             selectedDuration = active.duration
             let remaining = active.endsAt.timeIntervalSinceNow
@@ -48,6 +50,7 @@ final class DetoxTimerViewModel: ObservableObject {
         isRunning = true
         showCelebration = false
         startTimer()
+        focusAutomationManager.beginDetoxSession()
     }
 
     func requiresPaywallBeforeStartingSession() async -> (requiresPaywall: Bool, errorMessage: String?) {
@@ -74,6 +77,7 @@ final class DetoxTimerViewModel: ObservableObject {
         isRunning = false
         appState.recordSessionCompletion(session, aborted: true)
         appState.updateActiveSession(nil)
+        focusAutomationManager.endDetoxSession()
     }
 
     private func startTimer() {
@@ -102,6 +106,7 @@ final class DetoxTimerViewModel: ObservableObject {
         showCelebration = true
         appState.recordSessionCompletion(session, aborted: false)
         appState.updateActiveSession(nil)
+        focusAutomationManager.endDetoxSession()
     }
 
     private func stopTimer() {

--- a/Dopamine Detox/Views/DetoxTimerView.swift
+++ b/Dopamine Detox/Views/DetoxTimerView.swift
@@ -7,6 +7,8 @@ struct DetoxTimerView: View {
     @State private var isCheckingAccess = false
     @State private var showingPaywall = false
     @State private var paywallError: PaywallError?
+    @StateObject private var focusAutomation = FocusAutomationManager.shared
+    @Environment(\.scenePhase) private var scenePhase
 
     init(appState: AppState) {
         _viewModel = StateObject(wrappedValue: DetoxTimerViewModel(appState: appState))
@@ -103,18 +105,8 @@ struct DetoxTimerView: View {
                 .padding(.horizontal)
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                Label("Focus Filters ready", systemImage: "moon.zzz")
-                    .foregroundStyle(.secondary)
-                Text("When you start a detox, enable Focus Filters to silence distracting notifications.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-            .padding(.horizontal)
+            FocusAutomationCard(focusManager: focusAutomation)
+                .padding(.horizontal)
 
             Spacer()
         }
@@ -162,6 +154,12 @@ struct DetoxTimerView: View {
                 dismissButton: .default(Text("Entendido"))
             )
         }
+        .onAppear {
+            focusAutomation.refreshStatus()
+        }
+        .onChange(of: scenePhase) { _ in
+            focusAutomation.refreshStatus()
+        }
     }
 }
 
@@ -189,6 +187,120 @@ private struct CelebrationBanner: View {
 
 #Preview {
     DetoxTimerView(appState: AppState())
+}
+
+private struct FocusAutomationCard: View {
+    @ObservedObject var focusManager: FocusAutomationManager
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label {
+                Text(title)
+                    .font(.headline)
+            } icon: {
+                Image(systemName: iconName)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(description)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            if let actionTitle = actionTitle {
+                Button(actionTitle) {
+                    Task { await performPrimaryAction() }
+                }
+                .buttonStyle(useProminentButton ? .borderedProminent : .bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private var title: String {
+        switch focusManager.status {
+        case .unsupported:
+            return "Focus Filters not available"
+        case .needsAuthorization:
+            return "Authorize Focus Filters"
+        case .denied:
+            return "Focus Filters denied"
+        case .needsConfiguration:
+            return "Choose a Focus to silence notifications"
+        case .ready(let name):
+            return "\(name) will auto-activate"
+        }
+    }
+
+    private var description: String {
+        switch focusManager.status {
+        case .unsupported:
+            return "Update to the latest iOS version to silence notifications automatically during detox sessions."
+        case .needsAuthorization:
+            return "Allow Dopamine Detox to control Focus Filters so we can mute notifications when a session begins."
+        case .denied:
+            return "You previously denied Focus Filters access. Enable it in Settings to silence notifications automatically."
+        case .needsConfiguration:
+            return "Pick which Focus mode the app should enable each time you start a detox."
+        case .ready(let name):
+            return "We'll enable \(name) as soon as your detox starts and disable it when you finish."
+        }
+    }
+
+    private var iconName: String {
+        switch focusManager.status {
+        case .ready:
+            return "moon.zzz.fill"
+        case .unsupported, .needsAuthorization, .needsConfiguration, .denied:
+            return "moon.zzz"
+        }
+    }
+
+    private var actionTitle: String? {
+        switch focusManager.status {
+        case .unsupported:
+            return nil
+        case .needsAuthorization:
+            return "Enable Focus Filters"
+        case .denied:
+            return "Open Settings"
+        case .needsConfiguration:
+            return "Choose Focus"
+        case .ready:
+            return "Change Focus"
+        }
+    }
+
+    private var useProminentButton: Bool {
+        switch focusManager.status {
+        case .ready:
+            return false
+        case .unsupported, .needsAuthorization, .needsConfiguration, .denied:
+            return true
+        }
+    }
+
+    private func performPrimaryAction() async {
+        switch focusManager.status {
+        case .unsupported:
+            break
+        case .needsAuthorization:
+            await focusManager.requestAuthorizationIfNeeded()
+        case .needsConfiguration, .ready:
+            await focusManager.presentConfigurationPicker(from: activeWindowScene())
+        case .denied:
+            focusManager.openSettings()
+        }
+    }
+
+    private func activeWindowScene() -> UIWindowScene? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+    }
 }
 
 private extension DetoxTimerView {


### PR DESCRIPTION
## Summary
- add a FocusAutomationManager service that stores the selected Focus configuration and activates it with Apple's Focus Filter APIs when detox sessions start
- trigger Focus Filter activation/deactivation from the detox timer view model so notifications are muted during active sessions
- refresh the detox timer view with a Focus Filters setup card that guides users through authorization and configuration states

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68e2909263c8832bb22c71727f253c20