### PR TITLE
Fix detox chart to use completion date

### DIFF
--- a/Dopamine Detox/Views/DashboardView.swift
+++ b/Dopamine Detox/Views/DashboardView.swift
@@ -105,7 +105,11 @@ struct DashboardView: View {
 
         return pastSevenDays.map { day in
             let totalMinutes = appState.pastSessions
-                .filter { calendar.isDate($0.startedAt, inSameDayAs: day) && !$0.aborted }
+                .filter { session in
+                    guard !session.aborted else { return false }
+                    let referenceDate = session.completedAt ?? session.startedAt
+                    return calendar.isDate(referenceDate, inSameDayAs: day)
+                }
                 .reduce(0) { $0 + Int($1.duration.rawValue / 60) }
             return SessionBar(date: day, minutes: totalMinutes)
         }


### PR DESCRIPTION
## Summary
- update the dashboard chart to count detox minutes based on the session completion date so finished detoxes appear in the weekly view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c758f658832b8bb06e84b2c03931