### PR TITLE
Fix paywall log string interpolation in DetoxTimerView

### DIFF
--- a/Dopamine Detox/Views/DetoxTimerView.swift
+++ b/Dopamine Detox/Views/DetoxTimerView.swift
@@ -284,9 +284,12 @@ private extension DetoxTimerView {
             paywallLogger.info(
                 "requiresPaywallBeforeStartingSession returned requiresPaywall=\(result.requiresPaywall, privacy: .public) error=\(result.errorMessage ?? \"nil\", privacy: .public)"
             )
+            let requiresPaywallText = result.requiresPaywall ? "sí" : "no"
+            let errorText = result.errorMessage ?? "ninguno"
+
             showPaywallLog(
                 level: .info,
-                message: "Resultado de la comprobación: requierePaywall=\(result.requiresPaywall ? \"sí\" : \"no\") error=\(result.errorMessage ?? \"ninguno\")"
+                message: "Resultado de la comprobación: requierePaywall=\(requiresPaywallText) error=\(errorText)"
             )
 
             await MainActor.run {


### PR DESCRIPTION
## Summary
- derive localized text for paywall requirement and error values before logging
- use the derived values in the paywall status log message to avoid nested interpolations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b8824328832b931d9f84ba4934b6