### PR TITLE
Fix app shortcut configuration for calm wall intent

### DIFF
--- a/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
+++ b/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
@@ -24,7 +24,7 @@ struct ShowCalmWallIntent: AppIntent {
             throw ShowCalmWallIntentError.invalidConfiguration
         }
 
-        return .result(opening: url)
+        return .result(value: url)
     }
 }
 
@@ -33,18 +33,16 @@ struct DotoxAppShortcuts: AppShortcutsProvider {
     static var shortcutTileColor: ShortcutTileColor = .blue
 
     static var appShortcuts: [AppShortcut] {
-        [
-            AppShortcut(
-                intent: ShowCalmWallIntent(),
-                phrases: [
-                    "Mostrar muro de calma en \(.applicationName)",
-                    "Abrir Dotox",
-                    "Quiero calma antes de usar \(.applicationName)"
-                ],
-                shortTitle: "Muro de calma",
-                systemImageName: "brain.head.profile"
-            )
-        ]
+        AppShortcut(
+            intent: ShowCalmWallIntent(),
+            phrases: [
+                "Mostrar muro de calma en \(.applicationName)",
+                "Abrir Dotox",
+                "Quiero calma antes de usar \(.applicationName)"
+            ],
+            shortTitle: "Muro de calma",
+            systemImageName: "brain.head.profile"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- update the calm wall intent to return an IntentResult using the `value:` label expected by the AppIntents API
- adjust the shortcuts provider to rely on the AppShortcuts builder rather than an explicit array literal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60b582334832bb7a1cabd835634b6