### PR TITLE
Fix App Shortcut utterances to include application name

### DIFF
--- a/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
+++ b/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
@@ -37,7 +37,7 @@ struct DotoxAppShortcuts: AppShortcutsProvider {
             intent: ShowCalmWallIntent(),
             phrases: [
                 "Mostrar muro de calma en \(.applicationName)",
-                "Abrir Dotox",
+                "Abrir Dotox antes de usar \(.applicationName)",
                 "Quiero calma antes de usar \(.applicationName)"
             ],
             shortTitle: "Muro de calma",


### PR DESCRIPTION
## Summary
- ensure each App Shortcut phrase references the target application name to satisfy validation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e60e1a00a8832b8a951dfcebfeb25a