### PR TITLE
Simplify calm wall automation to avoid redirect errors

### DIFF
--- a/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
+++ b/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
@@ -10,17 +10,12 @@ struct ShowCalmWallIntent: AppIntent {
     @Parameter(title: "Nombre de la app", default: "Instagram")
     var appName: String
 
-    @Parameter(title: "URL para continuar", default: "")
-    var redirectTarget: String
-
     static var parameterSummary: some ParameterSummary {
-        Summary("Mostrar muro de calma antes de abrir \(\.$appName)") {
-            \.$redirectTarget
-        }
+        Summary("Mostrar muro de calma antes de abrir \(\.$appName)")
     }
 
     func perform() async throws -> some IntentResult {
-        guard let url = AppConfiguration.makeDetoxInterventionURL(appName: appName, redirectTarget: redirectTarget) else {
+        guard let url = AppConfiguration.makeDetoxInterventionURL(appName: appName) else {
             throw ShowCalmWallIntentError.invalidConfiguration
         }
 

--- a/Dopamine Detox/Configuration/AppConfiguration.swift
+++ b/Dopamine Detox/Configuration/AppConfiguration.swift
@@ -4,7 +4,7 @@ enum AppConfiguration {
     static let detoxInterventionScheme = "dopaminedetox"
     static let detoxInterventionHost = "intervention"
 
-    static func makeDetoxInterventionURL(appName: String, redirectTarget: String) -> URL? {
+    static func makeDetoxInterventionURL(appName: String) -> URL? {
         var components = URLComponents()
         components.scheme = detoxInterventionScheme
         components.host = detoxInterventionHost
@@ -14,11 +14,6 @@ enum AppConfiguration {
         let trimmedAppName = appName.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedAppName.isEmpty {
             items.append(URLQueryItem(name: "app", value: trimmedAppName))
-        }
-
-        let trimmedRedirectTarget = redirectTarget.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedRedirectTarget.isEmpty {
-            items.append(URLQueryItem(name: "redirect", value: trimmedRedirectTarget))
         }
 
         components.queryItems = items.isEmpty ? nil : items

--- a/Dopamine Detox/Dopamine_DetoxApp.swift
+++ b/Dopamine Detox/Dopamine_DetoxApp.swift
@@ -32,15 +32,6 @@ private extension Dopamine_DetoxApp {
 
         let appName = components.queryItems?.first(where: { $0.name == "app" })?.value ?? ""
 
-        let redirectURL: URL?
-        if let redirectValue = components.queryItems?.first(where: { $0.name == "redirect" })?.value,
-           !redirectValue.isEmpty {
-            let decoded = redirectValue.removingPercentEncoding ?? redirectValue
-            redirectURL = URL(string: decoded)
-        } else {
-            redirectURL = nil
-        }
-
-        appState.presentIntervention(appName: appName, redirectURL: redirectURL)
+        appState.presentIntervention(appName: appName)
     }
 }

--- a/Dopamine Detox/Models/AppState.swift
+++ b/Dopamine Detox/Models/AppState.swift
@@ -106,8 +106,8 @@ final class AppState: ObservableObject {
         journalEntries.insert(entry, at: 0)
     }
 
-    func presentIntervention(appName: String, redirectURL: URL?) {
-        pendingIntervention = DetoxIntervention(appName: appName, redirectURL: redirectURL)
+    func presentIntervention(appName: String) {
+        pendingIntervention = DetoxIntervention(appName: appName)
     }
 
     func clearIntervention() {

--- a/Dopamine Detox/Models/DetoxIntervention.swift
+++ b/Dopamine Detox/Models/DetoxIntervention.swift
@@ -3,8 +3,6 @@ import Foundation
 struct DetoxIntervention: Identifiable, Equatable {
     let id = UUID()
     let appName: String
-    let redirectURL: URL?
-
     var displayName: String {
         let trimmed = appName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "la app" : trimmed

--- a/Dopamine Detox/Views/Components/DetoxInterventionWall.swift
+++ b/Dopamine Detox/Views/Components/DetoxInterventionWall.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SwiftUI
-import UIKit
 
 struct DetoxInterventionWall: View {
     let intervention: DetoxIntervention
@@ -53,18 +52,13 @@ struct DetoxInterventionWall: View {
                         }
                         .buttonStyle(.borderedProminent)
 
-                        if let redirectURL = intervention.redirectURL {
-                            Button {
-                                onDismiss()
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                                    UIApplication.shared.open(redirectURL, options: [:], completionHandler: nil)
-                                }
-                            } label: {
-                                Text("Continuar a \(intervention.displayName)")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.bordered)
+                        Button {
+                            onDismiss()
+                        } label: {
+                            Text("Continuar igualmente")
+                                .frame(maxWidth: .infinity)
                         }
+                        .buttonStyle(.bordered)
                     }
                 }
                 .padding()
@@ -86,7 +80,7 @@ struct DetoxInterventionWall: View {
 
 #Preview {
     DetoxInterventionWall(
-        intervention: DetoxIntervention(appName: "Instagram", redirectURL: URL(string: "instagram://app")),
+        intervention: DetoxIntervention(appName: "Instagram"),
         onDismiss: {}
     )
 }

--- a/Dopamine Detox/Views/Components/ShortcutAutomationCard.swift
+++ b/Dopamine Detox/Views/Components/ShortcutAutomationCard.swift
@@ -4,12 +4,11 @@ import UIKit
 
 struct ShortcutAutomationCard: View {
     @State private var appName: String = "Instagram"
-    @State private var redirectTarget: String = "instagram://app"
     @State private var didCopyLink = false
     @State private var showingInstructions = false
 
     private var shortcutURL: URL? {
-        AppConfiguration.makeDetoxInterventionURL(appName: appName, redirectTarget: redirectTarget)
+        AppConfiguration.makeDetoxInterventionURL(appName: appName)
     }
 
     var body: some View {
@@ -36,7 +35,7 @@ struct ShortcutAutomationCard: View {
             .controlSize(.large)
 
             VStack(alignment: .leading, spacing: 12) {
-                Text("Personaliza el enlace")
+                Text("Configura el enlace")
                     .font(.subheadline)
                     .fontWeight(.semibold)
 
@@ -44,12 +43,6 @@ struct ShortcutAutomationCard: View {
                     .textInputAutocapitalization(.words)
                     .disableAutocorrection(true)
                     .textFieldStyle(.roundedBorder)
-
-                TextField("URL para continuar", text: $redirectTarget)
-                    .textInputAutocapitalization(.never)
-                    .disableAutocorrection(true)
-                    .textFieldStyle(.roundedBorder)
-                    .keyboardType(.URL)
 
                 if let urlString = shortcutURL?.absoluteString {
                     Text(urlString)
@@ -87,9 +80,6 @@ struct ShortcutAutomationCard: View {
         .onChange(of: appName) { _ in
             didCopyLink = false
         }
-        .onChange(of: redirectTarget) { _ in
-            didCopyLink = false
-        }
         .sheet(isPresented: $showingInstructions) {
             NavigationStack {
                 ScrollView {
@@ -100,15 +90,11 @@ struct ShortcutAutomationCard: View {
                         VStack(alignment: .leading, spacing: 16) {
                             StepView(number: 1, text: "En la app Atajos, crea una Automatización Personal al abrir la app que te distrae.")
                             StepView(number: 2, text: "Pulsa Añadir acción, ve a Apps → Dotox y selecciona \"Mostrar muro de calma\".")
-                            StepView(number: 3, text: "Rellena el nombre de la app y pega el enlace personalizado. Desactiva \"Preguntar antes de ejecutar\".")
+                            StepView(number: 3, text: "Introduce el nombre de la app en Dotox y desactiva \"Preguntar antes de ejecutar\".")
                         }
 
                         VStack(alignment: .leading, spacing: 12) {
                             Text("Si no ves Dotox en la lista de apps, ábrela una vez y vuelve a Atajos para actualizar las acciones disponibles.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-
-                            Text("El campo \"URL para continuar\" te permite volver automáticamente a la app original tras completar el muro de calma.")
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }


### PR DESCRIPTION
## Summary
- remove the redirect URL parameter from the calm wall shortcut and the underlying configuration
- simplify the intervention sheet and automation card copy now that redirects are no longer supported

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6a36fedd4832ba098688ccf5a034e