### PR TITLE
Fix app shortcut placeholder references

### DIFF
--- a/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
+++ b/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
@@ -34,9 +34,9 @@ struct DotoxAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: ShowCalmWallIntent(),
             phrases: [
-                "Mostrar muro de calma en \(.applicationName)",
-                "Abrir Dotox antes de usar \(.applicationName)",
-                "Quiero calma antes de usar \(.applicationName)"
+                "Mostrar muro de calma en \(.appName)",
+                "Abrir Dotox antes de usar \(.appName)",
+                "Quiero calma antes de usar \(.appName)"
             ],
             shortTitle: "Muro de calma",
             systemImageName: "brain.head.profile"


### PR DESCRIPTION
## Summary
- update the shortcut phrases for ShowCalmWallIntent to reference the appName parameter correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e74c2fd1c0832bb0cbad18c601e296