### PR TITLE
Fix App Intent parameter summary interpolation

### DIFF
--- a/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
+++ b/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
@@ -13,7 +13,7 @@ struct ShowCalmWallIntent: AppIntent {
     var appName: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Mostrar muro de calma antes de abrir", \.$appName)
+        Summary("Mostrar muro de calma antes de abrir \(.$appName)")
     }
 
     func perform() async throws -> some IntentResult {


### PR DESCRIPTION
## Summary
- update the ShowCalmWallIntent parameter summary to use string interpolation instead of passing the key path directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e78e781e04832b84b43e607f81d9d8