### PR TITLE
Fix calm wall shortcut to open the app with intervention URL

### DIFF
--- a/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
+++ b/Dopamine Detox/AppShortcuts/DotoxAppShortcuts.swift
@@ -14,8 +14,11 @@ struct ShowCalmWallIntent: AppIntent {
     }
     
     func perform() async throws -> some IntentResult {
-        // La URL se manejará en el AppDelegate/SceneDelegate cuando la app se abra
-        return .result()
+        guard let url = AppConfiguration.makeDetoxInterventionURL(appName: appName) else {
+            return .result()
+        }
+
+        return .openApp(at: url)
     }
 }
 

--- a/Dopamine Detox/Configuration/AppConfiguration.swift
+++ b/Dopamine Detox/Configuration/AppConfiguration.swift
@@ -1,7 +1,14 @@
 import Foundation
 
 enum AppConfiguration {
+    /// Custom URL scheme declared in Info.plist under `URL types` so the system knows
+    /// the Dopamine Detox app can be opened with links that start with
+    /// `dopaminedetox://`.
     static let detoxInterventionScheme = "dopaminedetox"
+
+    /// Host used for the intervention deep link. Combined with the scheme above it
+    /// builds `dopaminedetox://intervention` which the app handles in
+    /// `Dopamine_DetoxApp.handle(url:)` to present the calm wall.
     static let detoxInterventionHost = "intervention"
 
     static func makeDetoxInterventionURL(appName: String) -> URL? {


### PR DESCRIPTION
## Summary
- update the calm wall shortcut intent to build the intervention deeplink
- ensure the intent opens the Dopamine Detox app with the deeplink so the calm wall appears
- document the registered deep link scheme and host the shortcut relies on

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68e7ac48394c832ba192346a0590b4ff