### PR TITLE
Fix detox automation URL scheme

### DIFF
--- a/Dopamine Detox/Configuration/AppConfiguration.swift
+++ b/Dopamine Detox/Configuration/AppConfiguration.swift
@@ -3,11 +3,11 @@ import Foundation
 enum AppConfiguration {
     /// Custom URL scheme declared in Info.plist under `URL types` so the system knows
     /// the Dopamine Detox app can be opened with links that start with
-    /// `dopaminedetox://`.
-    static let detoxInterventionScheme = "dopaminedetox"
+    /// `dotox://`.
+    static let detoxInterventionScheme = "dotox"
 
     /// Host used for the intervention deep link. Combined with the scheme above it
-    /// builds `dopaminedetox://intervention` which the app handles in
+    /// builds `dotox://intervention` which the app handles in
     /// `Dopamine_DetoxApp.handle(url:)` to present the calm wall.
     static let detoxInterventionHost = "intervention"
 


### PR DESCRIPTION
## Summary
- align the detox intervention deep link scheme with the app's registered `dotox://` URL
- update inline documentation to reflect the corrected scheme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7fc87ba44832baddbccb0e8bbae95